### PR TITLE
Update clear-cache.php

### DIFF
--- a/clear-cache.php
+++ b/clear-cache.php
@@ -1,2 +1,2 @@
 <?php
-	apc_clear_cache();
+	apc_clear_cache(); opcache_reset();


### PR DESCRIPTION
Bytecode is now cached by OPcache and must be reset separately from APC, which is now only a key-value store.